### PR TITLE
Switch strings hardcoded -> g:message

### DIFF
--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -153,6 +153,17 @@ homepage.wordlists=Wortlisten
 homepage.download=Download
 homepage.api=Webservice / API
 homepage.imprint=Impressum
+homepage.tagline=OpenThesaurus ist ein freies deutsches Synonymwörterbuch, bei dem jeder mitmachen kann.
+homepage.claim=Synonyme und Assoziationen
+homepage.search=Suchwort
+
+footer.android=OpenThesaurus für
+footer.twitter=Folge uns auf
+footer.rss=auch per
+footer.email=Schreibe uns eine
+footer.login=Einlogen
+footer.join=und mitmachen
+
 search.button=Synonym finden
 austrian.words=Österreichische Wörter
 swiss.words=Schweizer Wörter

--- a/grails-app/views/_footer.gsp
+++ b/grails-app/views/_footer.gsp
@@ -3,7 +3,7 @@
     <tr>
       <td height="120" width="370" class="claim" colspan="2">
         <div style="margin-bottom: 20px">
-          OpenThesaurus ist ein freies deutsches Synonymwörterbuch, bei dem jeder mitmachen kann.
+          <g:message code="homepage.tagline"/>
         </div>
       </td>
       <td width="60"></td>
@@ -73,7 +73,7 @@
                 <td>&nbsp;</td>
                 <td>
                     <g:link controller="user" action="login" class="lightlink"
-                       params="${linkParams}"><strong>Einloggen</strong> und mitmachen</g:link>
+                       params="${linkParams}"><strong><g:message code="footer.login"/></strong> <g:message code="footer.join"/></g:link>
                 </td>
             </g:else>
             </tr>
@@ -97,7 +97,7 @@
                 <!--
                 var firstPart = "feedback";
                 var lastPart = "openthesaurus.de";
-                document.write("<a class=\"lightlink\" href='mail" + "to:" + firstPart + "@" + lastPart + "'>Schreibe uns eine <strong>E-Mail<" + "/strong><" + "/a>");
+                document.write("<a class=\"lightlink\" href='mail" + "to:" + firstPart + "@" + lastPart + "'><g:message code="footer.email"/> <strong>Email<" + "/strong><" + "/a>");
                 // -->
                 </script>
               </td>
@@ -109,18 +109,18 @@
             <tr>
               <td><a href="http://twitter.com/openthesaurus"><img src="${createLinkTo(dir:'images',file:'icon-twitter.png')}" width="30" height="30" alt="Twitter-Icon"/></a></td>
               <td>&nbsp;</td>
-              <td><a class="lightlink" href="http://twitter.com/openthesaurus">Folge uns auf <strong>twitter</strong></a>
-                 <span style="font-weight: normal;"> - auch per</span> <a href="http://api.twitter.com/1/statuses/user_timeline.rss?screen_name=openthesaurus">RSS</a></td>
+              <td><a class="lightlink" href="http://twitter.com/openthesaurus"><g:message code="footer.twitter"/> <strong>twitter</strong></a>
+                 <span style="font-weight: normal;"> - <g:message code="footer.rss"/></span> <a href="http://api.twitter.com/1/statuses/user_timeline.rss?screen_name=openthesaurus">RSS</a></td>
             </tr>
           </table>
         </div>
-        <%--
         <div class="iconLink">
+        <%--
           <table>
             <tr>
               <td><a href="http://www.androidpit.de/de/android/market/apps/app/com.fc.ot/OpenThesaurus-fuer-Android"><img src="${createLinkTo(dir:'images',file:'icon-android.png')}" alt="Android-Icon"/></a></td>
               <td>&nbsp;</td>
-              <td><a class="lightlink" href="http://www.androidpit.de/de/android/market/apps/app/com.fc.ot/OpenThesaurus-fuer-Android">OpenThesaurus für <strong>Android</strong></a></td>
+              <td><a class="lightlink" href="http://www.androidpit.de/de/android/market/apps/app/com.fc.ot/OpenThesaurus-fuer-Android"><g:message code="footer.android"/> <strong>Android</strong></a></td>
             </tr>
           </table>
         </div>

--- a/grails-app/views/_searchform.gsp
+++ b/grails-app/views/_searchform.gsp
@@ -13,7 +13,7 @@
         alt="<g:message code='logo.alt.text'/>" width="341" height="93" /></a></div>
   </g:else>
 
-  <p class="claim">Synonyme und Assoziationen</p>
+  <p class="claim"><g:message code="homepage.claim"/></p>
     
   <form action="${createLinkTo(dir:'synonyme')}" onsubmit="window.location='${createLinkTo(dir:'synonyme')}/' + encodeURIComponent(document.searchform.q.value.replace('/', '___'));return false;" name="searchform">
 
@@ -28,7 +28,7 @@
       <input ${directSearchAttributes} style="outline: none" onclick="selectSearchField()" onblur="leaveSearchField()" accesskey="s" type="text" id="search-field" name="q" value="${StringTools.slashUnescape(params.q.encodeAsHTML())}" /><input style="border-width:0px" type="image" title="Synonym finden" src="${createLinkTo(dir:'images',file:'search-submit.png')}" />
     </g:if>
     <g:else>
-      <input ${directSearchAttributes} style="outline: none" onclick="selectSearchField()" onblur="leaveSearchField()" accesskey="s" type="text" id="search-field" name="q" value="Suchwort" /><input style="border-width:0px" type="image" title="Synonym finden" src="${createLinkTo(dir:'images',file:'search-submit.png')}" />
+      <input ${directSearchAttributes} style="outline: none" onclick="selectSearchField()" onblur="leaveSearchField()" accesskey="s" type="text" id="search-field" name="q" value="<g:message code="homepage.search"/>" /><input style="border-width:0px" type="image" title="Synonym finden" src="${createLinkTo(dir:'images',file:'search-submit.png')}" />
     </g:else>
     <g:if test="${isDirectSearch}">
     </g:if>


### PR DESCRIPTION
Switch strings from hardcoded german to translatable via "g:message"
in
    views/_footer.gsp and
    views/_searchform.gsp

and moved the actual strings in messages.properties. These conversions
help translating openthesaurus to other languages (starting from Greek).
