### PR TITLE
Add Greek accented characters to TERM_REGEXP

### DIFF
--- a/grails-app/domain/com/vionto/vithesaurus/Term.groovy
+++ b/grails-app/domain/com/vionto/vithesaurus/Term.groovy
@@ -38,7 +38,7 @@ class Term implements Comparable, Cloneable {
     /** Allowed term expression. TODO: read from configuration */
     final static String TERM_REGEXP =
         "[ 0-9a-zA-ZöäüÖÄÜßëçèéêáàóòÈÉÁÀÓÒãñíîş\\{\\}\\\"\\?\\*=()\\-\\+/.,'_:<>;%°" +
-            "\\!\\[\\]²³&#αΑβΒγΓδΔεΕζΖηΗθΘιΙκΚλΛμΜνΝξΞοΟπΠρΡσΣτΤυΥφΦχΧψΨωΩœ]+"
+            "\\!\\[\\]²³&#αΑβΒγΓδΔεΕζΖηΗθΘιΙκΚλΛμΜνΝξΞοΟπΠρΡσΣτΤυΥφΦχΧψΨωΩάΆέΈίΊήΉύΎϊϋΰΐœ]+"
 
     static belongsTo = [synset:Synset]
     


### PR DESCRIPTION
TERM_REGEXP was missing Greek accented characters which made it impossible
to add new Greek words. This patch adds them.
